### PR TITLE
Upgrade base images from Python 3.10 to Python 3.12

### DIFF
--- a/cpu-baseimage.dockerfile
+++ b/cpu-baseimage.dockerfile
@@ -18,7 +18,7 @@ RUN apt-get -y update && \
     python3.12 -m ensurepip && \
     python3.12 -m pip install --upgrade pip && \
 # some pip packages -------------------------------------------------------------------------------------------
-    python3.12 -m pip install "numpy>=2.0" pyyaml typing_extensions future six requests dataclasses minio dash plotly pandas && \
+    python3.12 -m pip install --ignore-installed "numpy>=2.0" pyyaml typing_extensions future six requests dataclasses minio dash plotly pandas && \
 # compiled from source dependencies ---------------------------------------------------------------------------
 # lastool  ---------------------------------------------------------------------------------------------------
     mkdir /opt/build && mkdir /opt/deps && cd /opt/deps &&  \

--- a/cpu-baseimage.dockerfile
+++ b/cpu-baseimage.dockerfile
@@ -23,7 +23,7 @@ RUN apt-get -y update && \
 # lastool  ---------------------------------------------------------------------------------------------------
     mkdir /opt/build && mkdir /opt/deps && cd /opt/deps &&  \
     git clone https://github.com/LAStools/LAStools && \
-    cd LAStools && git checkout 9bdc92c && cmake -DCMAKE_BUILD_TYPE=Release . && make -j install && \
+    cd LAStools && git checkout 9bdc92c && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_POLICY_VERSION_MINIMUM=3.5 . && make -j install && \
 # PyTorch, CPU only -----------------------------------------------------------------------------------------
 # options : MAX_JOBS core build. c++11 abi.
     cd /opt/deps && \

--- a/cpu-baseimage.dockerfile
+++ b/cpu-baseimage.dockerfile
@@ -1,4 +1,4 @@
-# PyTorch
+# PyTorch (Python 3.12)
 # This Dockerfile creates a comprehensive environment with PyTorch built from source.
 # Build process could take 10+ hours. Change MAX_JOBS for faster building time.
 FROM ubuntu:22.04
@@ -6,26 +6,33 @@ ENV DEBIAN_FRONTEND=noninteractive
 WORKDIR /opt
 # apt packages ------------------------------------------------------------------------------------------------
 RUN apt-get -y update && \
+    apt-get -y install software-properties-common && \
+    add-apt-repository -y ppa:deadsnakes/ppa && \
+    apt-get -y update && \
     apt-get -y install build-essential cmake curl git libeigen3-dev \
                        libjsoncpp-dev libtbb-dev liblz4-dev \
-                       libyaml-cpp-dev wget zip python3 python3-pip python3-dev pybind11-dev && \
-    pip install --upgrade pip && \
+                       libyaml-cpp-dev wget zip \
+                       python3.12 python3.12-dev python3.12-venv \
+                       pybind11-dev && \
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1 && \
+    python3.12 -m ensurepip && \
+    python3.12 -m pip install --upgrade pip && \
 # some pip packages -------------------------------------------------------------------------------------------
-    pip install numpy==1.26.* pyyaml typing_extensions future six requests dataclasses minio dash plotly pandas && \
+    python3.12 -m pip install "numpy>=2.0" pyyaml typing_extensions future six requests dataclasses minio dash plotly pandas && \
 # compiled from source dependencies ---------------------------------------------------------------------------
 # lastool  ---------------------------------------------------------------------------------------------------
     mkdir /opt/build && mkdir /opt/deps && cd /opt/deps &&  \
     git clone https://github.com/LAStools/LAStools && \
     cd LAStools && git checkout 9bdc92c && cmake -DCMAKE_BUILD_TYPE=Release . && make -j install && \
-# PyTorch, with cuda support ---------------------------------------------------------------------------------
-# options : MAX_JOBS core build. c++11 abi. TORCH_CUDA_ARCH_LIST controls which gpu can be used
+# PyTorch, CPU only -----------------------------------------------------------------------------------------
+# options : MAX_JOBS core build. c++11 abi.
     cd /opt/deps && \
     git clone --depth 1  --recursive https://github.com/pytorch/pytorch && \
     cd pytorch && \
     git submodule sync && \
     git submodule update --init --recursive && \
-    _GLIBCXX_USE_CXX11_ABI=1 MAX_JOBS=4 USE_NINJA=1   python3 setup.py bdist_wheel && \
-    pip install dist/torch-*.whl && \
+    _GLIBCXX_USE_CXX11_ABI=1 MAX_JOBS=4 USE_NINJA=1 python3.12 setup.py bdist_wheel && \
+    python3.12 -m pip install dist/torch-*.whl && \
     cd build && cmake --install . --prefix /usr/local && \
 # cleanup the source deps files
     cd / && rm -r /opt/deps

--- a/cpu-baseimage.dockerfile
+++ b/cpu-baseimage.dockerfile
@@ -27,8 +27,9 @@ RUN apt-get -y update && \
 # PyTorch, CPU only -----------------------------------------------------------------------------------------
 # options : MAX_JOBS core build. c++11 abi.
     cd /opt/deps && \
-    git clone --depth 1  --recursive https://github.com/pytorch/pytorch && \
+    git clone --recursive https://github.com/pytorch/pytorch && \
     cd pytorch && \
+    git checkout 8fff7e3 && \
     git submodule sync && \
     git submodule update --init --recursive && \
     _GLIBCXX_USE_CXX11_ABI=1 MAX_JOBS=4 USE_NINJA=1 python3.12 setup.py bdist_wheel && \

--- a/cpu-baseimage.dockerfile
+++ b/cpu-baseimage.dockerfile
@@ -18,7 +18,7 @@ RUN apt-get -y update && \
     python3.12 -m ensurepip && \
     python3.12 -m pip install --upgrade pip && \
 # some pip packages -------------------------------------------------------------------------------------------
-    python3.12 -m pip install --ignore-installed "numpy>=2.0" pyyaml typing_extensions future six requests dataclasses minio dash plotly pandas && \
+    python3.12 -m pip install --ignore-installed cmake "numpy>=2.0" pyyaml typing_extensions future six requests dataclasses minio dash plotly pandas && \
 # compiled from source dependencies ---------------------------------------------------------------------------
 # lastool  ---------------------------------------------------------------------------------------------------
     mkdir /opt/build && mkdir /opt/deps && cd /opt/deps &&  \
@@ -27,9 +27,8 @@ RUN apt-get -y update && \
 # PyTorch, CPU only -----------------------------------------------------------------------------------------
 # options : MAX_JOBS core build. c++11 abi.
     cd /opt/deps && \
-    git clone --recursive https://github.com/pytorch/pytorch && \
+    git clone --depth 1 --recursive https://github.com/pytorch/pytorch && \
     cd pytorch && \
-    git checkout 8fff7e3 && \
     git submodule sync && \
     git submodule update --init --recursive && \
     _GLIBCXX_USE_CXX11_ABI=1 MAX_JOBS=4 USE_NINJA=1 python3.12 setup.py bdist_wheel && \

--- a/cuda-baseimage.dockerfile
+++ b/cuda-baseimage.dockerfile
@@ -18,7 +18,7 @@ RUN apt-get -y update && \
     python3.12 -m ensurepip && \
     python3.12 -m pip install --upgrade pip && \
 # some pip packages -------------------------------------------------------------------------------------------
-    python3.12 -m pip install --ignore-installed "numpy>=2.0" pyyaml typing_extensions future six requests dataclasses minio dash plotly pandas && \
+    python3.12 -m pip install --ignore-installed cmake "numpy>=2.0" pyyaml typing_extensions future six requests dataclasses minio dash plotly pandas && \
 # compiled from source dependencies ---------------------------------------------------------------------------
 # lastool  ---------------------------------------------------------------------------------------------------
     mkdir /opt/build && mkdir /opt/deps && cd /opt/deps &&  \
@@ -27,9 +27,8 @@ RUN apt-get -y update && \
 # PyTorch, with cuda support ---------------------------------------------------------------------------------
 # options : MAX_JOBS core build. c++11 abi. TORCH_CUDA_ARCH_LIST controls which gpu can be used
     cd /opt/deps && \
-    git clone --recursive https://github.com/pytorch/pytorch && \
+    git clone --depth 1 --recursive https://github.com/pytorch/pytorch && \
     cd pytorch && \
-    git checkout 8fff7e3 && \
     git submodule sync && \
     git submodule update --init --recursive && \
     GLIBCXX_USE_CXX11_ABI=1 USE_NINJA=1 MAX_JOBS=2 USE_CUDA=1 USE_CUDNN=1 TORCH_CUDA_ARCH_LIST="8.0" python3.12 setup.py bdist_wheel && \

--- a/cuda-baseimage.dockerfile
+++ b/cuda-baseimage.dockerfile
@@ -23,7 +23,7 @@ RUN apt-get -y update && \
 # lastool  ---------------------------------------------------------------------------------------------------
     mkdir /opt/build && mkdir /opt/deps && cd /opt/deps &&  \
     git clone https://github.com/LAStools/LAStools && \
-    cd LAStools && git checkout 9bdc92c && cmake -DCMAKE_BUILD_TYPE=Release . && make -j install && \
+    cd LAStools && git checkout 9bdc92c && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_POLICY_VERSION_MINIMUM=3.5 . && make -j install && \
 # PyTorch, with cuda support ---------------------------------------------------------------------------------
 # options : MAX_JOBS core build. c++11 abi. TORCH_CUDA_ARCH_LIST controls which gpu can be used
     cd /opt/deps && \

--- a/cuda-baseimage.dockerfile
+++ b/cuda-baseimage.dockerfile
@@ -27,8 +27,9 @@ RUN apt-get -y update && \
 # PyTorch, with cuda support ---------------------------------------------------------------------------------
 # options : MAX_JOBS core build. c++11 abi. TORCH_CUDA_ARCH_LIST controls which gpu can be used
     cd /opt/deps && \
-    git clone --depth 1  --recursive https://github.com/pytorch/pytorch && \
+    git clone --recursive https://github.com/pytorch/pytorch && \
     cd pytorch && \
+    git checkout 8fff7e3 && \
     git submodule sync && \
     git submodule update --init --recursive && \
     GLIBCXX_USE_CXX11_ABI=1 USE_NINJA=1 MAX_JOBS=2 USE_CUDA=1 USE_CUDNN=1 TORCH_CUDA_ARCH_LIST="8.0" python3.12 setup.py bdist_wheel && \

--- a/cuda-baseimage.dockerfile
+++ b/cuda-baseimage.dockerfile
@@ -1,4 +1,4 @@
-# NVIDIA CUDA Development Environment with PyTorch
+# NVIDIA CUDA Development Environment with PyTorch (Python 3.12)
 # This Dockerfile creates a comprehensive CUDA-enabled environment with PyTorch built from source.
 # Build process could take 10+ hours. Change MAX_JOBS for faster building time.
 FROM nvidia/cuda:12.2.2-devel-ubuntu22.04
@@ -6,12 +6,19 @@ ENV DEBIAN_FRONTEND=noninteractive
 WORKDIR /opt
 # apt packages ------------------------------------------------------------------------------------------------
 RUN apt-get -y update && \
+    apt-get -y install software-properties-common && \
+    add-apt-repository -y ppa:deadsnakes/ppa && \
+    apt-get -y update && \
     apt-get -y install build-essential cmake curl git libeigen3-dev \
                        libjsoncpp-dev libtbb-dev liblz4-dev \
-                       libyaml-cpp-dev wget zip python3 python3-pip python3-dev pybind11-dev && \
-    pip install --upgrade pip && \
+                       libyaml-cpp-dev wget zip \
+                       python3.12 python3.12-dev python3.12-venv \
+                       pybind11-dev && \
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1 && \
+    python3.12 -m ensurepip && \
+    python3.12 -m pip install --upgrade pip && \
 # some pip packages -------------------------------------------------------------------------------------------
-    pip install numpy==1.26.* pyyaml typing_extensions future six requests dataclasses minio dash plotly pandas && \
+    python3.12 -m pip install "numpy>=2.0" pyyaml typing_extensions future six requests dataclasses minio dash plotly pandas && \
 # compiled from source dependencies ---------------------------------------------------------------------------
 # lastool  ---------------------------------------------------------------------------------------------------
     mkdir /opt/build && mkdir /opt/deps && cd /opt/deps &&  \
@@ -24,8 +31,8 @@ RUN apt-get -y update && \
     cd pytorch && \
     git submodule sync && \
     git submodule update --init --recursive && \
-    GLIBCXX_USE_CXX11_ABI=1 USE_NINJA=1 MAX_JOBS=2 USE_CUDA=1 USE_CUDNN=1 TORCH_CUDA_ARCH_LIST="8.0" python3 setup.py bdist_wheel && \
-    pip install dist/torch-*.whl && \
+    GLIBCXX_USE_CXX11_ABI=1 USE_NINJA=1 MAX_JOBS=2 USE_CUDA=1 USE_CUDNN=1 TORCH_CUDA_ARCH_LIST="8.0" python3.12 setup.py bdist_wheel && \
+    python3.12 -m pip install dist/torch-*.whl && \
     cd build && cmake --install . --prefix /usr/local && \
     # cleanup the source deps files
     cd / && rm -r /opt/deps

--- a/cuda-baseimage.dockerfile
+++ b/cuda-baseimage.dockerfile
@@ -18,7 +18,7 @@ RUN apt-get -y update && \
     python3.12 -m ensurepip && \
     python3.12 -m pip install --upgrade pip && \
 # some pip packages -------------------------------------------------------------------------------------------
-    python3.12 -m pip install "numpy>=2.0" pyyaml typing_extensions future six requests dataclasses minio dash plotly pandas && \
+    python3.12 -m pip install --ignore-installed "numpy>=2.0" pyyaml typing_extensions future six requests dataclasses minio dash plotly pandas && \
 # compiled from source dependencies ---------------------------------------------------------------------------
 # lastool  ---------------------------------------------------------------------------------------------------
     mkdir /opt/build && mkdir /opt/deps && cd /opt/deps &&  \


### PR DESCRIPTION
Install Python 3.12 via deadsnakes PPA on Ubuntu 22.04 instead of using the system Python 3.10. This aligns the base images with copernnet's pyproject.toml requirement of Python >=3.12.

- Add deadsnakes PPA and install python3.12, python3.12-dev, python3.12-venv
- Set python3.12 as default via update-alternatives
- Use python3.12 -m pip instead of bare pip
- Update numpy from ==1.26.* to >=2.0 (proper Python 3.12 support)
- Keep CUDA 12.2.2 and all CXX11 ABI build flags unchanged
