### PR TITLE
Build CPU pytorch image with Intel MKL

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,7 +35,6 @@ jobs:
   build:
     timeout-minutes: 1440
     runs-on: pepibru
-    if: github.event_name != 'workflow_dispatch' || inputs.target == 'all' || inputs.target == matrix.target_key
     strategy:
       matrix:
         include:
@@ -129,6 +128,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
+        if: github.event_name != 'workflow_dispatch' || inputs.target == 'all' || inputs.target == matrix.target_key
         uses: docker/build-push-action@v6.9.0
         with:
           context: ${{ matrix.context }}
@@ -146,7 +146,7 @@ jobs:
       # transparency data even for private images, pass --force to cosign below.
       # https://github.com/sigstore/cosign
       - name: Sign the published Docker image
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.target == 'all' || inputs.target == matrix.target_key) }}
         env:
           # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
           TAGS: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,22 +7,6 @@ on:
     tags: [ 'v*.*.*' ]
   pull_request:
     branches: [ "main" ]
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: "Docker tag to publish under (e.g. mkl-test, mkl-test-2)"
-        required: true
-        default: "mkl-test"
-        type: string
-      target:
-        description: "Which matrix entries to build"
-        required: true
-        default: "cpu"
-        type: choice
-        options:
-          - cpu
-          - cuda
-          - all
 
 env:
   # Use docker.io for Docker Hub if empty
@@ -43,12 +27,10 @@ jobs:
             dockerfile: ./cpu-baseimage.dockerfile
             buildargs: |
               DUMMY=yes
-            target_key: cpu
           - image: pytorch-cuda
             dockerfile: ./cuda-baseimage.dockerfile
             buildargs: |
               DUMMY=yes
-            target_key: cuda
     permissions:
       contents: read
       packages: write
@@ -117,18 +99,11 @@ jobs:
         uses: docker/metadata-action@v5.5.1
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-${{ matrix.image }}
-          tags: |
-            type=schedule
-            type=ref,event=branch
-            type=ref,event=tag
-            type=ref,event=pr
-            type=raw,value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        if: github.event_name != 'workflow_dispatch' || inputs.target == 'all' || inputs.target == matrix.target_key
         uses: docker/build-push-action@v6.9.0
         with:
           context: ${{ matrix.context }}
@@ -146,7 +121,7 @@ jobs:
       # transparency data even for private images, pass --force to cosign below.
       # https://github.com/sigstore/cosign
       - name: Sign the published Docker image
-        if: ${{ github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.target == 'all' || inputs.target == matrix.target_key) }}
+        if: ${{ github.event_name != 'pull_request' }}
         env:
           # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
           TAGS: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,6 +7,22 @@ on:
     tags: [ 'v*.*.*' ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Docker tag to publish under (e.g. mkl-test, mkl-test-2)"
+        required: true
+        default: "mkl-test"
+        type: string
+      target:
+        description: "Which matrix entries to build"
+        required: true
+        default: "cpu"
+        type: choice
+        options:
+          - cpu
+          - cuda
+          - all
 
 env:
   # Use docker.io for Docker Hub if empty
@@ -19,6 +35,7 @@ jobs:
   build:
     timeout-minutes: 1440
     runs-on: pepibru
+    if: github.event_name != 'workflow_dispatch' || inputs.target == 'all' || inputs.target == matrix.target_key
     strategy:
       matrix:
         include:
@@ -27,10 +44,12 @@ jobs:
             dockerfile: ./cpu-baseimage.dockerfile
             buildargs: |
               DUMMY=yes
+            target_key: cpu
           - image: pytorch-cuda
             dockerfile: ./cuda-baseimage.dockerfile
             buildargs: |
               DUMMY=yes
+            target_key: cuda
     permissions:
       contents: read
       packages: write
@@ -99,6 +118,12 @@ jobs:
         uses: docker/metadata-action@v5.5.1
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-${{ matrix.image }}
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=raw,value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action

--- a/cpu-baseimage.dockerfile
+++ b/cpu-baseimage.dockerfile
@@ -20,7 +20,7 @@ RUN apt-get -y update && \
                        libjsoncpp-dev libtbb-dev liblz4-dev \
                        libyaml-cpp-dev wget zip python3 python3-pip python3-dev pybind11-dev \
                        intel-oneapi-mkl-devel && \
-    pip install --upgrade pip setuptools wheel && \
+    pip install --upgrade pip setuptools wheel cmake && \
 # some pip packages -------------------------------------------------------------------------------------------
     pip install numpy==1.26.* pyyaml typing_extensions future six requests dataclasses minio dash plotly pandas && \
 # compiled from source dependencies ---------------------------------------------------------------------------

--- a/cpu-baseimage.dockerfile
+++ b/cpu-baseimage.dockerfile
@@ -39,7 +39,7 @@ RUN apt-get -y update && \
         BLAS=MKL MKLROOT=${MKLROOT} USE_MKLDNN=1 \
         python3 setup.py bdist_wheel && \
     pip install dist/torch-*.whl && \
-    python3 -c "import torch; print(torch.__config__.show())" | tee /opt/torch_config.txt && \
+    (cd / && python3 -c "import torch; print(torch.__config__.show())") | tee /opt/torch_config.txt && \
     grep -q 'USE_MKL=ON' /opt/torch_config.txt && \
     grep -qi 'BLAS_INFO=mkl' /opt/torch_config.txt && \
     cd build && cmake --install . --prefix /usr/local && \

--- a/cpu-baseimage.dockerfile
+++ b/cpu-baseimage.dockerfile
@@ -20,7 +20,7 @@ RUN apt-get -y update && \
                        libjsoncpp-dev libtbb-dev liblz4-dev \
                        libyaml-cpp-dev wget zip python3 python3-pip python3-dev pybind11-dev \
                        intel-oneapi-mkl-devel && \
-    pip install --upgrade pip setuptools wheel cmake && \
+    pip install --upgrade pip setuptools wheel "cmake>=3.27,<4" && \
 # some pip packages -------------------------------------------------------------------------------------------
     pip install numpy==1.26.* pyyaml typing_extensions future six requests dataclasses minio dash plotly pandas && \
 # compiled from source dependencies ---------------------------------------------------------------------------

--- a/cpu-baseimage.dockerfile
+++ b/cpu-baseimage.dockerfile
@@ -13,14 +13,14 @@ RUN apt-get -y update && \
         > /etc/apt/sources.list.d/oneAPI.list
 # MKL env (set before PyTorch build so cmake's FindMKL picks it up) -------------------------------------------
 ENV MKLROOT=/opt/intel/oneapi/mkl/latest
-ENV LD_LIBRARY_PATH=${MKLROOT}/lib/intel64:${LD_LIBRARY_PATH}
+ENV LD_LIBRARY_PATH=${MKLROOT}/lib/intel64
 # apt packages ------------------------------------------------------------------------------------------------
 RUN apt-get -y update && \
     apt-get -y install build-essential cmake curl git libeigen3-dev \
                        libjsoncpp-dev libtbb-dev liblz4-dev \
                        libyaml-cpp-dev wget zip python3 python3-pip python3-dev pybind11-dev \
                        intel-oneapi-mkl-devel && \
-    pip install --upgrade pip && \
+    pip install --upgrade pip setuptools wheel && \
 # some pip packages -------------------------------------------------------------------------------------------
     pip install numpy==1.26.* pyyaml typing_extensions future six requests dataclasses minio dash plotly pandas && \
 # compiled from source dependencies ---------------------------------------------------------------------------

--- a/cpu-baseimage.dockerfile
+++ b/cpu-baseimage.dockerfile
@@ -4,11 +4,22 @@
 FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 WORKDIR /opt
+# Intel oneAPI APT repo (for MKL) -----------------------------------------------------------------------------
+RUN apt-get -y update && \
+    apt-get -y install --no-install-recommends ca-certificates curl gnupg && \
+    curl -fsSL https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
+        | gpg --dearmor -o /usr/share/keyrings/oneapi-archive-keyring.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" \
+        > /etc/apt/sources.list.d/oneAPI.list
+# MKL env (set before PyTorch build so cmake's FindMKL picks it up) -------------------------------------------
+ENV MKLROOT=/opt/intel/oneapi/mkl/latest
+ENV LD_LIBRARY_PATH=${MKLROOT}/lib/intel64:${LD_LIBRARY_PATH}
 # apt packages ------------------------------------------------------------------------------------------------
 RUN apt-get -y update && \
     apt-get -y install build-essential cmake curl git libeigen3-dev \
                        libjsoncpp-dev libtbb-dev liblz4-dev \
-                       libyaml-cpp-dev wget zip python3 python3-pip python3-dev pybind11-dev && \
+                       libyaml-cpp-dev wget zip python3 python3-pip python3-dev pybind11-dev \
+                       intel-oneapi-mkl-devel && \
     pip install --upgrade pip && \
 # some pip packages -------------------------------------------------------------------------------------------
     pip install numpy==1.26.* pyyaml typing_extensions future six requests dataclasses minio dash plotly pandas && \
@@ -24,8 +35,13 @@ RUN apt-get -y update && \
     cd pytorch && \
     git submodule sync && \
     git submodule update --init --recursive && \
-    _GLIBCXX_USE_CXX11_ABI=1 MAX_JOBS=4 USE_NINJA=1   python3 setup.py bdist_wheel && \
+    _GLIBCXX_USE_CXX11_ABI=1 MAX_JOBS=4 USE_NINJA=1 \
+        BLAS=MKL MKLROOT=${MKLROOT} USE_MKLDNN=1 \
+        python3 setup.py bdist_wheel && \
     pip install dist/torch-*.whl && \
+    python3 -c "import torch; print(torch.__config__.show())" | tee /opt/torch_config.txt && \
+    grep -q 'USE_MKL=ON' /opt/torch_config.txt && \
+    grep -qi 'BLAS_INFO=mkl' /opt/torch_config.txt && \
     cd build && cmake --install . --prefix /usr/local && \
 # cleanup the source deps files
     cd / && rm -r /opt/deps

--- a/cuda-baseimage.dockerfile
+++ b/cuda-baseimage.dockerfile
@@ -9,7 +9,7 @@ RUN apt-get -y update && \
     apt-get -y install build-essential cmake curl git libeigen3-dev \
                        libjsoncpp-dev libtbb-dev liblz4-dev \
                        libyaml-cpp-dev wget zip python3 python3-pip python3-dev pybind11-dev && \
-    pip install --upgrade pip && \
+    pip install --upgrade pip setuptools wheel "cmake>=3.27,<4" && \
 # some pip packages -------------------------------------------------------------------------------------------
     pip install numpy==1.26.* pyyaml typing_extensions future six requests dataclasses minio dash plotly pandas && \
 # compiled from source dependencies ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Switch `cpu-baseimage.dockerfile` to install Intel oneAPI MKL and build PyTorch with `BLAS=MKL` + `USE_MKLDNN=1`, so the cxx11-ABI CPU image uses MKL as its BLAS backend instead of OpenBLAS.
- Bump pip-installed `setuptools`, `wheel` and `cmake` (pinned `>=3.27,<4`) in both CPU and CUDA dockerfiles so the current PyTorch HEAD source build succeeds on Ubuntu 22.04 (newer setuptools for `setuptools.command.bdist_wheel`, newer cmake for PyTorch's minimum, capped below 4 so LAStools still configures). The CUDA fix is unrelated to MKL — main was already broken for the same HEAD-drift reasons; bundled here so the PR build goes green.
- Add a post-build sanity check (CPU image only) that fails the docker build if `USE_MKL=ON` / `BLAS_INFO=mkl` aren't present in `torch.__config__.show()`, so we can't silently publish a non-MKL CPU image.

CI workflow is unchanged from main — the MKL image was validated under a temporary `mkl-test` tag using a throwaway `workflow_dispatch` trigger that has since been reverted. On merge, the normal `push: branches: [main]` trigger republishes both `pytorch-cpu` (now with MKL) and `pytorch-cuda` under the standard tags.

## Test plan

- [x] CPU source build completes through `setup.py bdist_wheel` (verified in dispatch run on `feature/cpu-mkl`)
- [x] `torch.__config__.show()` reports `USE_MKL=ON` and `BLAS_INFO=mkl` for the CPU image (enforced as a hard build-time gate)
- [x] `cmake --install` lands the cxx11-ABI LibTorch under `/usr/local` in the CPU image
- [ ] CUDA build now also gets past `setup.py` and produces a wheel (PR build will exercise this)
- [ ] Pull `ghcr.io/kapernikov/pytorch-cxx11abi-pytorch-cpu:main` after merge and run a quick matmul to confirm the published image works
- [ ] Optionally verify a downstream LibTorch consumer still links

🤖 Generated with [Claude Code](https://claude.com/claude-code)